### PR TITLE
Add "chromeapp" field to `package.json`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,24 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
       - name: Install dependencies
-        run: npm i
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm i
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - name: Install dependencies
+        run: npm i
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# [1.3.0](https://github.com/webtorrent/http-node/compare/v1.2.0...v1.3.0) (2022-01-14)
+
+
+### Bug Fixes
+
+* add semantic release config ([c524325](https://github.com/webtorrent/http-node/commit/c524325db9efdf082760ebf01c672863cfea87a1))
+
+
+### Features
+
+* webtorrent org, semantic release ([65665fd](https://github.com/webtorrent/http-node/commit/65665fddc31bb12883702d8ac2b4743be1da0f4c))

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "http-node",
+  "name": "@webtorrent/http-node",
   "version": "1.2.0",
   "description": "Node.js http as a standalone package",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jscissr/http-node.git"
+    "url": "git://github.com/webtorrent/http-node.git"
   },
   "main": "http.js",
   "license": "MIT",
@@ -18,5 +18,11 @@
   "author": {
     "name": "Jan Schär",
     "email": "jscissr@gmail.com"
+  },
+  "devDependencies": {
+    "semantic-release": "^18.0.1"
+  },
+  "release": {
+    "extends": "@webtorrent/semantic-release-config"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "email": "jscissr@gmail.com"
   },
   "devDependencies": {
+    "@webtorrent/semantic-release-config": "^1.0.7",
     "semantic-release": "^18.0.1"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webtorrent/http-node",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Node.js http as a standalone package",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "main": "http.js",
   "license": "MIT",
+  "chromeapp": {
+    "net": "chrome-net"
+  },
   "dependencies": {
     "freelist": "^1.0.3",
     "http-parser-js": "^0.4.3"


### PR DESCRIPTION
I'm attempting to make a defacto standard for specifying Chrome App dependency substitutions using the `"chromeapp"` field in `package.json`.

The `"chromeapp"` field is just like the [`"browser"` field in `package.json`](https://github.com/defunctzombie/package-browser-field-spec) except it's intended for Chrome Apps instead of a generic browser environment. Bundler tools like `browserify` or `webpack` can be configured to look for the `"chromeapp"` field instead of the `"browser"` field when doing a build for a Chrome App.

In this specific package, since Chrome Apps can use raw sockets we want to replace `require('net')` with `require('chrome-net')`.

